### PR TITLE
Fix test_cli_reads_and_executes_commands hanging indefinitely

### DIFF
--- a/rounds/tests/test_cli_interactive.py
+++ b/rounds/tests/test_cli_interactive.py
@@ -6,6 +6,7 @@ Covers:
 - JSON command parsing
 """
 
+import asyncio
 import json
 from unittest.mock import patch
 
@@ -31,8 +32,9 @@ class TestInteractiveCLILoop:
         ]
 
         with patch("builtins.input", side_effect=commands):
-            # Should complete without error
-            await _run_cli_interactive(handler)
+            # Timeout prevents indefinite hang if input mock fails to intercept
+            # the run_in_executor thread (e.g. in CI environments with blocking stdin)
+            await asyncio.wait_for(_run_cli_interactive(handler), timeout=10.0)
 
     async def test_cli_handles_json_parse_errors(self) -> None:
         """Test that CLI handles malformed JSON gracefully."""


### PR DESCRIPTION
## Summary
- Adds `asyncio.wait_for(..., timeout=10.0)` to the interactive CLI test that was hanging indefinitely
- The `run_in_executor` thread used for blocking stdin reads was not being cancelled when the mock input was exhausted, causing the test to hang forever in CI environments

## Test plan
- [ ] Run `pytest tests/test_cli_interactive.py` — should complete in < 15s (was: never completes)
- [ ] Verify timeout raises `asyncio.TimeoutError` if mock input fails, not a silent hang

Fixes #65

🤖 Generated with [Codetoreum](https://github.com/tinkermonkey/codetoreum) + [Claude Code](https://claude.com/claude-code)